### PR TITLE
Calculate length correctly with ANSI escape codes

### DIFF
--- a/lib/length.js
+++ b/lib/length.js
@@ -1,10 +1,11 @@
 /**
  * string length
  * */
+var stripAnsi = require('strip-ansi');
 var cache = {};
 
 module.exports = function (str) {
-    str = "" + str;
+    str = stripAnsi("" + str);
     if (str in cache) {
         return cache[str];
     }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/mangix/term-grid/issues"
   },
-  "homepage": "https://github.com/mangix/term-grid"
+  "homepage": "https://github.com/mangix/term-grid",
+  "dependencies": {
+    "strip-ansi": "^2.0.1"
+  }
 }


### PR DESCRIPTION
I was looking to do some more advanced string formatting using [chalk](https://github.com/sindresorhus/chalk) in my terminal grids and found the cell length was being incorrectly calculated when you passed a string that for example had been colorized and bolded.

This uses the strip-ansi package (which is powering the equivalent functionality in Chalk) to calculate the length of the string to be printed after first excluding any ansi escape sequences in the string.
## Sample Code:

``` js
var Grid = require('term-grid');
var chalk = require('chalk');

var header = chalk.green.bold;
var grid = new Grid([
    [header('Name'), header('Age'), header('City')],
    ["Allan", 20, "New York"],
    ["Jack", 30, "London"]
]);
grid.draw();
```
## Before Fix

![screen shot 2015-04-20 at 5 29 26 pm](https://cloud.githubusercontent.com/assets/66679/7243522/f922a91c-e782-11e4-8dd2-38b630d5dcc1.png)
## After Fix

![screen shot 2015-04-20 at 5 30 04 pm](https://cloud.githubusercontent.com/assets/66679/7243525/00a4961e-e783-11e4-877e-f197f69456a3.png)
